### PR TITLE
Don't count comments in 'return' problem

### DIFF
--- a/src/return/problem1.js
+++ b/src/return/problem1.js
@@ -1,6 +1,5 @@
 // Remove as many characters from this function without changing its meaning.
 // In other words, make this function as succinct as possible
-// Also, remove these comments
 
 function f(x) {
   if (x > 10) {

--- a/test/return/problem1.js
+++ b/test/return/problem1.js
@@ -6,8 +6,12 @@ let fs = require('fs');
 let source = fs
   .readFileSync(__dirname + '/../../src/return/problem1.js')
   .toString();
+
+// Don't count any comments
+source = source.replace(/\/\/.*/g, '');
+
+// Don't count whitespace
 source = source.replace(/\s/g, '');
-console.log(source);
 
 describe('Source', function() {
   it('is less than 85 characters', function() {


### PR DESCRIPTION
Two students thought "Also, remove these comments" only referred to Line 3, and were confused when their test was failing (while lines 1/2 were still there).

I added a quick regex to strip comments from source before counting